### PR TITLE
dawarich: Split deployments and toggle persistence

### DIFF
--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -92,42 +92,60 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "dawarich.volumes" -}}
+{{- if .Values.persistence.gemCache.enabled }}
 - name: gem-cache
   persistentVolumeClaim:
     claimName: {{ default (printf "%s-gem-cache" (include "dawarich.fullname" .)) .Values.persistence.gemCache.existingClaim }}
+{{- end }}
+{{- if .Values.persistence.public.enabled }}
 - name: public
   persistentVolumeClaim:
     claimName: {{ default (printf "%s-public" (include "dawarich.fullname" .)) .Values.persistence.public.existingClaim }}
+{{- end }}
+{{- if .Values.persistence.watched.enabled }}
 - name: watched
   persistentVolumeClaim:
     claimName: {{ default (printf "%s-watched" (include "dawarich.fullname" .)) .Values.persistence.watched.existingClaim }}
+{{- end }}
 {{- if .Values.dawarich.extraVolumes }}
-{{ toYaml .Values.dawarich.extraVolumes }}
+{{ toYaml .Values.dawarich.extraVolumes | indent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "dawarich.volumeMounts" -}}
+{{- if .Values.persistence.gemCache.enabled }}
 - name: gem-cache
   mountPath: /usr/local/bundle/gems
+{{- end }}
+{{- if .Values.persistence.public.enabled }}
 - name: public
   mountPath: /var/app/public
+{{- end }}
+{{- if .Values.persistence.watched.enabled }}
 - name: watched
   mountPath: /var/app/tmp/imports/watched
+{{- end }}
 {{- if .Values.dawarich.extraVolumeMounts }}
-{{ toYaml .Values.dawarich.extraVolumeMounts }}
+{{ toYaml .Values.dawarich.extraVolumeMounts | indent 2 }}
 {{- end }}
 {{- end }}
 
 {{- define "dawarich.sidekiqVolumeMounts" -}}
+{{- if .Values.persistence.gemCache.enabled }}
 - name: gem-cache
   mountPath: /usr/local/bundle/gems
   readonly: true
+{{- end }}
+{{- if .Values.persistence.public.enabled }}
 - name: public
   mountPath: /var/app/public
   readonly: true
+{{- end }}
+{{- if .Values.persistence.watched.enabled }}
 - name: watched
   mountPath: /var/app/tmp/imports/watched
   readonly: true
+{{- end }}
 {{- end }}
 
 {{- define "dawarich.envFrom" -}}

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,6 +6,7 @@ metadata:
   labels:
     {{- include "dawarich.labels" . | nindent 4 }}
 spec:
+  replicas: {{ .Values.dawarich.replicaCount }}
   selector:
     matchLabels:
       {{- include "dawarich.selectorLabels" . | nindent 6 }}
@@ -52,6 +54,55 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- include "dawarich.volumeMounts" . | trim | nindent 12 }}
+      volumes:
+        {{- include "dawarich.volumes" . | trim | nindent 8 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dawarich.fullname" . }}-sidekiq
+  labels:
+    {{- include "dawarich.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.sidekiq.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "dawarich.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "dawarich.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "dawarich.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        {{ include "dawarich.initContainers" . | nindent 10 }}
+      containers:
         - name: {{ .Chart.Name }}-sidekiq
           command: ['sh', '-c', 'dev-entrypoint.sh sidekiq']
           envFrom:
@@ -62,12 +113,22 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          livenessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
+          readinessProbe:
+            exec:
+              command:
+                - "sh"
+                - "-c"
+                - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
             {{- include "dawarich.sidekiqVolumeMounts" . | trim | nindent 12 }}
-          {{- end }}
       volumes:
         {{- include "dawarich.volumes" . | trim | nindent 8 }}
       {{- with .Values.nodeSelector }}

--- a/charts/dawarich/templates/gem-cache-pvc.yaml
+++ b/charts/dawarich/templates/gem-cache-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.gemCache.existingClaim }}
+{{- if and (eq .Values.persistence.gemCache.enabled true) (not (empty .Values.persistence.gemCache.existingClaim)) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/dawarich/templates/public-pvc.yaml
+++ b/charts/dawarich/templates/public-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.public.existingClaim }}
+{{- if and (eq .Values.persistence.public.enabled true) (not (empty .Values.persistence.public.existingClaim)) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/dawarich/templates/watched-pvc.yaml
+++ b/charts/dawarich/templates/watched-pvc.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.persistence.watched.existingClaim }}
+{{- if and (eq .Values.persistence.watched.enabled true) (not (empty .Values.persistence.watched.existingClaim)) }}
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -11,6 +11,8 @@ image:
   tag: ""
 
 dawarich:
+  replicaCount: 1
+
   env:
     minMinutesSpentInCity: "60"
     applicationHost: "dawarich.example.org"
@@ -21,20 +23,26 @@ dawarich:
     photonApiHost: "photon.komoot.io"
     photonApiUseHttps: "true"
 
+sidekiq:
+  replicaCount: 1
+
 persistence:
   gemCache:
+    enabled: true
     existingClaim: ""
     annotations: []
     accessMode: "ReadWriteOnce"
     storageClass: ""
     size: 1Gi
   public:
+    enabled: true
     existingClaim: ""
     annotations: []
     accessMode: "ReadWriteOnce"
     storageClass: ""
     size: 10Gi
   watched:
+    enabled: true
     existingClaim: ""
     annotations: []
     accessMode: "ReadWriteOnce"
@@ -142,11 +150,11 @@ resources: {}
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
   httpGet:
-    path: /
+    path: /api/v1/health
     port: http
 readinessProbe:
   httpGet:
-    path: /
+    path: /api/v1/health
     port: http
 
 # Additional volumes on the output Deployment definition.


### PR DESCRIPTION
This PR introduces the following changes:

- Split Deployments: The app and Sidekiq have been split into separate deployments, allowing independent scaling.
- Disable Unused Volumes: Added the ability to disable unused public and watched volumes for better resource management. This is also useful to handle ReadWriteOnce restrictions when scaling.
- Change Probes: Liveness and Readiness probes changed to `/api/v1/health` and the sidekiq healthcheck. 

 All changes are fully backwards compatible, ensuring existing configurations remain unaffected.

Huge thanks to the @Cogitri for your work!