### PR TITLE
dawarich: Split deployment pod configurations

### DIFF
--- a/charts/dawarich/README.md
+++ b/charts/dawarich/README.md
@@ -40,7 +40,9 @@ Some of the most important values are documented below. Checkout the [values.yam
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| dawarich.env | object | See [values.yaml](./values.yaml) | Environment variables used for configuration of Dawarich |
+| env | object | See [values.yaml](./values.yaml) | Environment variables used for configuration of Dawarich |
+| dawarich | object | See [values.yaml](./values.yaml) | Pod configuration for the Dawarich deployment |
+| sidekiq | object | See [values.yaml](./values.yaml) | Pod configuration for the Sidekiq deployment |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"docker.io/freikin/dawarich"` | Image repository |
 | ingress | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -55,7 +55,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "dawarich.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "dawarich.name" . }}
+app.kubernetes.io/name: {{ include "dawarich.fullname" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/dawarich/templates/config-map.yaml
+++ b/charts/dawarich/templates/config-map.yaml
@@ -6,4 +6,4 @@ metadata:
     {{- include "dawarich.labels" . | nindent 4 }}
 data:
   RAILS_ENV: "development"
-  {{- include "dawarich.environmentSetup" (dict "environment" .Values.dawarich.env)}}
+  {{- include "dawarich.environmentSetup" (dict "environment" .Values.env)}}

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -12,10 +12,11 @@ spec:
       {{- include "dawarich.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        config-hash: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
       labels:
         {{- include "dawarich.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
@@ -47,24 +48,26 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml .Values.dawarich.livenessProbe | nindent 12 }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml .Values.dawarich.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.dawarich.startupProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.dawarich.resources | nindent 12 }}
           volumeMounts:
             {{- include "dawarich.volumeMounts" . | trim | nindent 12 }}
       volumes:
         {{- include "dawarich.volumes" . | trim | nindent 8 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.dawarich.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.dawarich.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.dawarich.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -75,20 +78,21 @@ kind: Deployment
 metadata:
   name: {{ include "dawarich.fullname" . }}-sidekiq
   labels:
-    {{- include "dawarich.labels" . | nindent 4 }}
+    {{- include "dawarich.labelsSidekiq" . | nindent 4 }}
 spec:
   replicas: {{ .Values.sidekiq.replicaCount }}
   selector:
     matchLabels:
-      {{- include "dawarich.selectorLabels" . | nindent 6 }}
+      {{- include "dawarich.selectorLabelsSidekiq" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- with .Values.podAnnotations }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+        config-hash: {{ include (print $.Template.BasePath "/config-map.yaml") . | sha256sum }}
       labels:
-        {{- include "dawarich.labels" . | nindent 8 }}
+        {{- include "dawarich.labelsSidekiq" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -114,32 +118,26 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
+            {{- toYaml .Values.sidekiq.livenessProbe | nindent 12 }}
           readinessProbe:
-            exec:
-              command:
-                - "sh"
-                - "-c"
-                - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
+            {{- toYaml .Values.sidekiq.readinessProbe | nindent 12 }}
+          startupProbe:
+            {{- toYaml .Values.sidekiq.startupProbe | nindent 12 }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.sidekiq.resources | nindent 12 }}
           volumeMounts:
             {{- include "dawarich.sidekiqVolumeMounts" . | trim | nindent 12 }}
       volumes:
         {{- include "dawarich.volumes" . | trim | nindent 8 }}
-      {{- with .Values.nodeSelector }}
+      {{- with .Values.sidekiq.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- with .Values.sidekiq.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- with .Values.sidekiq.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -10,21 +10,97 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+env:
+  minMinutesSpentInCity: "60"
+  applicationHost: "dawarich.example.org"
+  timeZone: "Europe/Berlin"
+  backgroundProcessingConcurrency: "10"
+  applicationProtocol: "http"
+  distanceUnit: "km"
+  photonApiHost: "photon.komoot.io"
+  photonApiUseHttps: "true"
+
 dawarich:
   replicaCount: 1
 
-  env:
-    minMinutesSpentInCity: "60"
-    applicationHost: "dawarich.example.org"
-    timeZone: "Europe/Berlin"
-    backgroundProcessingConcurrency: "10"
-    applicationProtocol: "http"
-    distanceUnit: "km"
-    photonApiHost: "photon.komoot.io"
-    photonApiUseHttps: "true"
+  # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe:
+    httpGet:
+      path: /api/v1/health
+      port: http
+  readinessProbe:
+    httpGet:
+      path: /api/v1/health
+      port: http
+  startupProbe:
+    httpGet:
+      path: /api/v1/health
+      port: http
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 10
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 500m
+    #   memory: 2Gi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 sidekiq:
   replicaCount: 1
+
+  # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+  livenessProbe:
+    exec:
+      command:
+        - "sh"
+        - "-c"
+        - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
+  readinessProbe:
+    exec:
+      command:
+        - "sh"
+        - "-c"
+        - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
+  startupProbe:
+    exec:
+      command:
+        - "sh"
+        - "-c"
+        - "bundle exec sidekiqmon processes | grep $${HOSTNAME}"
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    failureThreshold: 10
+
+  resources: {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 256Mi
+    # requests:
+    #   cpu: 500m
+    #   memory: 2Gi
+
+  nodeSelector: {}
+
+  tolerations: []
+
+  affinity: {}
 
 persistence:
   gemCache:
@@ -135,36 +211,8 @@ ingress:
   #    hosts:
   #      - chart-example.local
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-# This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  httpGet:
-    path: /api/v1/health
-    port: http
-readinessProbe:
-  httpGet:
-    path: /api/v1/health
-    port: http
-
 # Additional volumes on the output Deployment definition.
 extraVolumes: []
 
 # Additional volumeMounts on the output Deployment definition.
 extraVolumeMounts: []
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}


### PR DESCRIPTION
This PR builds upon and improves the changes introduced in #28, further refining the pod configurations for the `app` and `sidekiq` deployments. It enables more granular control and flexibility for each deployment.

#### Key Changes

1. **Refactored Environment Variables**:
   - Moved the `env` configuration to a top-level values object to simplify and centralize environment variable management.

2. **Deployment-Specific Configurations**:
   - Added support for separate `resources`, `nodeSelector`, `affinity`, and `tolerations` for the `app` and `sidekiq` deployments. This allows each deployment to target specific nodes and resource constraints.

3. **ConfigMap Hash Integration**:
   - Introduced a ConfigMap hash annotation to the deployments. This ensures the pods are updated whenever there are changes to the ConfigMap, improving configuration consistency.

4. **Startup Probes**:
   - Added `startupProbe` configurations with appropriate initial delays to both deployments, enhancing health checks during application startup and reducing false positives.

#### Why This Change?

- To decouple `app` and `sidekiq` deployments for better scalability and resource management.
- To ensure smoother rollouts when configuration changes are applied.
- To enhance pod lifecycle management with robust health checks.
