### PR TITLE
Bump Dawarich 0.24.1, Add PostGIS support

### DIFF
--- a/charts/dawarich/Chart.yaml
+++ b/charts/dawarich/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v2
 name: dawarich
 description: "Self-hosted alternative to Google Location History"
 type: application
-version: 0.6.0
+version: 0.6.1
 # renovate datasource=docker depName=docker.io/freikin/dawarich
-appVersion: "0.23.5"
+appVersion: "0.24.1"
 dependencies:
   - name: postgresql
     version: 16.4.14

--- a/charts/dawarich/templates/NOTES.txt
+++ b/charts/dawarich/templates/NOTES.txt
@@ -21,5 +21,5 @@
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
 2. Wait for the dawarich Pod to be ready (it takes up to a minute until postgresql & redis are ready for dawarich to function)
-3. Login with the default username (user@domain.com) and password (password)
-4. Click on the top-right button ("user@domain.com") -> "Account" to edit the email and password of the default account.
+3. Login with the default username (demo@dawarich.app) and password (password)
+4. Click on the top-right button ("demo@dawarich.app") -> "Account" to edit the email and password of the default account.

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -101,6 +101,9 @@ Create the name of the service account to use
 - name: watched
   persistentVolumeClaim:
     claimName: {{ default (printf "%s-watched" (include "dawarich.fullname" .)) .Values.persistence.watched.existingClaim }}
+{{- else }}
+- name: watched
+  type: emptyDir
 {{- end }}
 {{- if .Values.dawarich.extraVolumes }}
 {{ toYaml .Values.dawarich.extraVolumes | indent 2 }}
@@ -112,10 +115,8 @@ Create the name of the service account to use
 - name: public
   mountPath: /var/app/public
 {{- end }}
-{{- if .Values.persistence.watched.enabled }}
 - name: watched
   mountPath: /var/app/tmp/imports/watched
-{{- end }}
 {{- if .Values.dawarich.extraVolumeMounts }}
 {{ toYaml .Values.dawarich.extraVolumeMounts | indent 2 }}
 {{- end }}

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -103,7 +103,7 @@ Create the name of the service account to use
     claimName: {{ default (printf "%s-watched" (include "dawarich.fullname" .)) .Values.persistence.watched.existingClaim }}
 {{- else }}
 - name: watched
-  type: emptyDir
+  emptyDir: {}
 {{- end }}
 {{- if .Values.dawarich.extraVolumes }}
 {{ toYaml .Values.dawarich.extraVolumes | indent 2 }}

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
             - -c
             - |
               set -e
-              # psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
-              # echo "PostGIS extensions created successfully."
               psql -c "ALTER USER ${DB_USER} WITH SUPERUSER;"
           env:
             - name: PGHOST

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -31,7 +31,29 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
-        {{ include "dawarich.initContainers" . | nindent 10 }}
+        {{ include "dawarich.initContainers" . | nindent 8 }}
+        - name: postgis-init
+          image: bitnami/postgresql:latest
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              # psql -c "CREATE EXTENSION IF NOT EXISTS postgis;"
+              # echo "PostGIS extensions created successfully."
+              psql -c "ALTER USER ${DB_USER} WITH SUPERUSER;"
+          env:
+            - name: PGHOST
+              value: {{ include "dawarich.fullname" . }}-postgresql
+            - name: PGUSER
+              value: postgres
+            - name: PGPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "dawarich.fullname" . }}-postgresql
+                  key: postgres-password
+            - name: DB_USER
+              value: {{ .Values.postgresql.auth.username }}
       containers:
         - name: {{ .Chart.Name }}
           command: ['web-entrypoint.sh']

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -46,10 +46,10 @@ spec:
             - name: PGUSER
               value: postgres
             - name: PGPASSWORD
-              {{- if and .auth.existingSecret (ne .auth.existingSecret "") }}
+              {{- if and .Values.postgresql.auth.existingSecret (ne .auth.existingSecret "") }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .auth.existingSecret }}
+                  name: {{ .Values.postgresql.auth.existingSecret }}
                   key: postgres-password
               {{- else }}
               valueFrom:

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -46,17 +46,14 @@ spec:
             - name: PGUSER
               value: postgres
             - name: PGPASSWORD
-              {{- if and .Values.postgresql.auth.existingSecret (ne .auth.existingSecret "") }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.postgresql.auth.existingSecret }}
+                  name: {{- if .Values.postgresql.auth.existingSecret }}
+                    {{ .Values.postgresql.auth.existingSecret }}
+                  {{- else }}
+                    {{ $.Release.Name }}-postgresql
+                  {{- end }}
                   key: postgres-password
-              {{- else }}
-              valueFrom:
-                secretKeyRef:
-                  name: {{ $.Release.Name }}-postgresql
-                  key: postgres-password
-              {{- end }}
             - name: DB_USER
               value: {{ .Values.postgresql.auth.username }}
       containers:

--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -46,10 +46,17 @@ spec:
             - name: PGUSER
               value: postgres
             - name: PGPASSWORD
+              {{- if and .auth.existingSecret (ne .auth.existingSecret "") }}
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "dawarich.fullname" . }}-postgresql
+                  name: {{ .auth.existingSecret }}
                   key: postgres-password
+              {{- else }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Release.Name }}-postgresql
+                  key: postgres-password
+              {{- end }}
             - name: DB_USER
               value: {{ .Values.postgresql.auth.username }}
       containers:


### PR DESCRIPTION
- Upgrades Dawarich to 0.24.1
- Adds PostGIS support, enabling the extension via an init container
- Adds `emptyDir` for the watched directory if persistence is disabled, avoiding Dawarich errors with dir not found
- Updates post-deploy docs to reflect the new Dawarich default user

Closes #50 