### PR TITLE
Define new storage volume mount / 0.25.4 compatibility

### DIFF
--- a/charts/dawarich/README.md
+++ b/charts/dawarich/README.md
@@ -48,5 +48,7 @@ Some of the most important values are documented below. Checkout the [values.yam
 | ingress | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
 | persistence.public | object | See [values.yaml](./values.yaml) | Configure public volume settings for the chart under this key. |
 | persistence.export | object | See [values.yaml](./values.yaml) | Configure watched volume settings for the chart under this key. |
+| persistence.public | object | See [values.yaml](./values.yaml) | Configure public volume settings for the chart under this key. |
+| persistence.storage | object | See [values.yaml](./values.yaml) | Configure main storage volume settings for the chart under this key. |
 | postgresql | object | See [values.yaml](./values.yaml) | Configure postgresql database subchart under this key. Dawarich will automatically be configured to use the credentials supplied to postgresql. [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/postgresql) |
 | redis | object | See [values.yaml](./values.yaml) | Configure redis subchart under this key. Dawarich will automatically be configured to use the credentials supplied to postgresql. [[ref]](https://github.com/bitnami/charts/tree/main/bitnami/redis) |

--- a/charts/dawarich/README.md
+++ b/charts/dawarich/README.md
@@ -46,7 +46,6 @@ Some of the most important values are documented below. Checkout the [values.yam
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"docker.io/freikin/dawarich"` | Image repository |
 | ingress | object | See [values.yaml](./values.yaml) | Enable and configure ingress settings for the chart under this key. |
-| persistence.public | object | See [values.yaml](./values.yaml) | Configure public volume settings for the chart under this key. |
 | persistence.export | object | See [values.yaml](./values.yaml) | Configure watched volume settings for the chart under this key. |
 | persistence.public | object | See [values.yaml](./values.yaml) | Configure public volume settings for the chart under this key. |
 | persistence.storage | object | See [values.yaml](./values.yaml) | Configure main storage volume settings for the chart under this key. |

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -105,6 +105,11 @@ Create the name of the service account to use
 - name: watched
   emptyDir: {}
 {{- end }}
+{{- if .Values.persistence.storage.enabled }}
+- name: storage
+  persistentVolumeClaim:
+    claimName: {{ default (printf "%s-storage" (include "dawarich.fullname" .)) .Values.persistence.storage.existingClaim }}
+{{- end }}
 {{- if .Values.dawarich.extraVolumes }}
 {{ toYaml .Values.dawarich.extraVolumes | indent 2 }}
 {{- end }}
@@ -117,6 +122,10 @@ Create the name of the service account to use
 {{- end }}
 - name: watched
   mountPath: /var/app/tmp/imports/watched
+{{- if .Values.persistence.storage.enabled }}
+- name: storage
+  mountPath: /var/app/storage
+{{- end }}
 {{- if .Values.dawarich.extraVolumeMounts }}
 {{ toYaml .Values.dawarich.extraVolumeMounts | indent 2 }}
 {{- end }}
@@ -130,6 +139,10 @@ Create the name of the service account to use
 {{- if .Values.persistence.watched.enabled }}
 - name: watched
   mountPath: /var/app/tmp/imports/watched
+{{- end }}
+{{- if .Values.persistence.storage.enabled }}
+- name: storage
+  mountPath: /var/app/storage
 {{- end }}
 {{- end }}
 

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -152,6 +152,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "dawarich.env" -}}
+{{/* SELF_HOSTED is required in Dawarich >=0.25.4 */}}
+- name: SELF_HOSTED
+  value: "true"
 - name: APPLICATION_HOSTS
   value: {{ .Values.dawarich.host }}
 {{- with .Values.postgresql }}

--- a/charts/dawarich/templates/storage-pvc.yaml
+++ b/charts/dawarich/templates/storage-pvc.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.persistence.storage.enabled (not .Values.persistence.storage.existingClaim) }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "dawarich.fullname" . }}-storage
+  labels:
+    app.kubernetes.io/name: {{ include "dawarich.name" . }}
+    helm.sh/chart: {{ include "dawarich.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.persistence.storage.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.storage.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.storage.size | quote }}
+  {{- with .Values.persistence.storage.storageClass }}
+  {{- if (eq "-" .) }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ . }}"
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -93,6 +93,7 @@ sidekiq:
 
 persistence:
   public:
+    # This volume mounts to /var/app/public
     enabled: true
     existingClaim: ""
     annotations: []
@@ -100,12 +101,21 @@ persistence:
     storageClass: ""
     size: 10Gi
   watched:
+    # This volume mounts to /var/app/tmp/imports/watched
     enabled: true
     existingClaim: ""
     annotations: []
     accessMode: "ReadWriteOnce"
     storageClass: ""
     size: 10Gi
+  storage:
+    # This volume mounts to /var/app/storage
+    enabled: true
+    existingClaim: ""
+    annotations: []
+    accessMode: "ReadWriteOnce"
+    storageClass: ""
+    size: 5Gi
 
 postgresql:
   auth:


### PR DESCRIPTION
This PR adds a new `storage` definition for compliance with Dawarich `0.25.4` and newer.

It also sets the `SELF_HOSTED` envvar to true, which is also (apparently) required.

https://github.com/Freika/dawarich/releases/tag/0.25.4

Closes #89