### PR TITLE
Support custom admin password keys for Postgres

### DIFF
--- a/charts/dawarich/templates/deployment.yaml
+++ b/charts/dawarich/templates/deployment.yaml
@@ -54,7 +54,11 @@ spec:
                   {{- else }}
                     {{ $.Release.Name }}-postgresql
                   {{- end }}
-                  key: postgres-password
+                  key: {{- if .Values.postgresql.auth.secretKeys.adminPasswordKey }}
+                    {{ .Values.postgresql.auth.secretKeys.adminPasswordKey }}
+                  {{- else }}
+                    postgres-password
+                  {{- end }}
             - name: DB_USER
               value: {{ .Values.postgresql.auth.username }}
         {{- end }}  


### PR DESCRIPTION
Without this, using a custom key breaks the chart.