### PR TITLE
Fix jobs not being executed

### DIFF
--- a/charts/dawarich/Chart.yaml
+++ b/charts/dawarich/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dawarich
 description: "Self-hosted alternative to Google Location History"
 type: application
-version: 0.7.2
+version: 0.7.3
 # renovate datasource=docker depName=docker.io/freikin/dawarich
 appVersion: "0.27.2"
 dependencies:

--- a/charts/dawarich/templates/config-map.yaml
+++ b/charts/dawarich/templates/config-map.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "dawarich.labels" . | nindent 4 }}
 data:
-  RAILS_ENV: "production"
+  RAILS_ENV: "development"
   QUEUE_DATABASE_PATH: /var/app/solid/dawarich_queue.sqlite3
   CACHE_DATABASE_PATH: /var/app/solid/dawarich_cache.sqlite3
   CABLE_DATABASE_PATH: /var/app/solid/dawarich_cable.sqlite3


### PR DESCRIPTION
It seems the job queue only works when RAILS_ENV is set to development. With production, nothing runs and the /jobs page returns a 401 error.