### PR TITLE
Support geocoding API keys

### DIFF
--- a/charts/dawarich/Chart.yaml
+++ b/charts/dawarich/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dawarich
 description: "Self-hosted alternative to Google Location History"
 type: application
-version: 0.8.5
+version: 0.8.6
 # renovate datasource=docker depName=docker.io/freikin/dawarich
 appVersion: "0.30.6"
 dependencies:

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -220,6 +220,27 @@ Create the name of the service account to use
       name: {{ include "dawarich.fullname" . }}
       key: keyBase
       {{- end }}
+- name: PHOTON_API_KEY
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.photonApiKey.existingSecret }}
+    name: {{ .Values.photonApiKey.existingSecret }}
+    key: {{ .Values.photonApiKey.existingSecretKeyName }}
+    {{- else }}
+    name: {{ include "dawarich.fullname" $ }}
+    key: photonApiKey
+    {{- end }}
+- name: GEOAPIFY_API_KEY
+  valueFrom:
+    secretKeyRef:
+    {{- if .Values.geoapifyApiKey.existingSecret }}
+    name: {{ .Values.geoapifyApiKey.existingSecret }}
+    key: {{ .Values.geoapifyApiKey.existingSecretKeyName }}
+    {{- else }}
+    name: {{ include "dawarich.fullname" $ }}
+    key: geoapifyApiKey
+    {{- end }}
+
 {{- end }}
 
 {{- define "dawarich.initContainers" }}

--- a/charts/dawarich/templates/secret.yaml
+++ b/charts/dawarich/templates/secret.yaml
@@ -18,3 +18,9 @@ data:
   {{- if and (not .Values.redis.enabled) (not .Values.redis.auth.existingSecret) }}
   redisPassword: {{ .Values.redis.auth.password | required ".redis.auth.password is required!" | b64enc }}
   {{- end }}
+  {{- if not .Values.photonApiKey.existingSecret }}
+  photonApiKey: {{ .Values.photonApiKey.value | b64enc }}
+  {{- end }}
+  {{- if not .Values.geoapifyApiKey.existingSecret }}
+  geoapifyApiKey: {{ .Values.geoapifyApiKey.value | b64enc }}
+  {{- end }}

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -24,6 +24,20 @@ env:
   prometheusExporterHost: "127.0.0.1"
   prometheusExporterPort: "9394"
   railsLogToStdout: "true"
+  photonApiHost: ""
+  photonApiUseHttps: ""
+
+# See https://dawarich.app/docs/tutorials/reverse-geocoding
+# Photon and Geoapify are mutually exclusive
+photonApiKey:
+  existingSecret: null
+  existingSecretKeyName: "key"
+  value: ""
+
+geoapifyApiKey:
+  existingSecret: null
+  existingSecretKeyName: "key"
+  value: ""
 
 dawarich:
   replicaCount: 1


### PR DESCRIPTION
This adds support for Photon and Geoapify API keys as documented upstream [1].

[1] https://dawarich.app/docs/tutorials/reverse-geocoding/