### PR TITLE
fix: Handle empty API key values gracefully in photon/geoapify secrets

### DIFF
--- a/charts/dawarich/Chart.yaml
+++ b/charts/dawarich/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: dawarich
 description: "Self-hosted alternative to Google Location History"
 type: application
-version: 0.8.9
+version: 0.8.10
 # renovate datasource=docker depName=docker.io/freikin/dawarich
 appVersion: "0.30.12"
 dependencies:

--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -221,25 +221,33 @@ Create the name of the service account to use
       key: keyBase
       {{- end }}
 - name: PHOTON_API_KEY
+  {{- if .Values.photonApiKey.existingSecret }}
   valueFrom:
     secretKeyRef:
-      {{- if .Values.photonApiKey.existingSecret }}
       name: {{ .Values.photonApiKey.existingSecret }}
       key: {{ .Values.photonApiKey.existingSecretKeyName }}
-      {{- else }}
-      name: {{ include "dawarich.fullname" $ }}
-      key: photonApiKey
-      {{- end }}
-- name: GEOAPIFY_API_KEY
+  {{- else if .Values.photonApiKey.value }}
   valueFrom:
     secretKeyRef:
-      {{- if .Values.geoapifyApiKey.existingSecret }}
+      name: {{ include "dawarich.fullname" $ }}
+      key: photonApiKey
+  {{- else }}
+  value: ""
+  {{- end }}
+- name: GEOAPIFY_API_KEY
+  {{- if .Values.geoapifyApiKey.existingSecret }}
+  valueFrom:
+    secretKeyRef:
       name: {{ .Values.geoapifyApiKey.existingSecret }}
       key: {{ .Values.geoapifyApiKey.existingSecretKeyName }}
-      {{- else }}
+  {{- else if .Values.geoapifyApiKey.value }}
+  valueFrom:
+    secretKeyRef:
       name: {{ include "dawarich.fullname" $ }}
       key: geoapifyApiKey
-      {{- end }}
+  {{- else }}
+  value: ""
+  {{- end }}
 
 {{- end }}
 

--- a/charts/dawarich/templates/secret.yaml
+++ b/charts/dawarich/templates/secret.yaml
@@ -18,9 +18,9 @@ data:
   {{- if and (not .Values.redis.enabled) (not .Values.redis.auth.existingSecret) }}
   redisPassword: {{ .Values.redis.auth.password | required ".redis.auth.password is required!" | b64enc }}
   {{- end }}
-  {{- if not .Values.photonApiKey.existingSecret }}
+  {{- if and (not .Values.photonApiKey.existingSecret) .Values.photonApiKey.value }}
   photonApiKey: {{ .Values.photonApiKey.value | b64enc }}
   {{- end }}
-  {{- if not .Values.geoapifyApiKey.existingSecret }}
+  {{- if and (not .Values.geoapifyApiKey.existingSecret) .Values.geoapifyApiKey.value }}
   geoapifyApiKey: {{ .Values.geoapifyApiKey.value | b64enc }}
   {{- end }}


### PR DESCRIPTION
This PR updates the handling for `photonApiKey` and `geoapifyApiKey` in the chart.

- If `existingSecret` is specified → use that secret and key.
- If `value` is provided → create a key in the release-managed Secret and reference it in the Pod env.
- If neither is provided → set the environment variable with an empty string (instead of referencing a non-existent Secret key).

Previously, if no secret or value was provided, Helm created an empty entry in the Secret. Kubernetes ignores empty Secret values, so Pods ended up referencing keys that didn’t exist, causing startup failures.
