### PR TITLE
Add selection of Redis database number

### DIFF
--- a/charts/dawarich/templates/_helpers.tpl
+++ b/charts/dawarich/templates/_helpers.tpl
@@ -202,7 +202,7 @@ Create the name of the service account to use
       {{- end }}
 {{- end }}
 - name: REDIS_URL
-  value: redis://{{ if .auth }}:$(A_REDIS_PASSWORD)@{{ end }}{{ tpl $.Values.redis.host $ }}:{{ .port }}
+  value: redis://{{ if .auth }}:$(A_REDIS_PASSWORD)@{{ end }}{{ tpl $.Values.redis.host $ }}:{{ .port }}/{{ .db | default 0 }}
 {{- end }}
 - name: SECRET_KEY_BASE
   valueFrom:

--- a/charts/dawarich/values.yaml
+++ b/charts/dawarich/values.yaml
@@ -147,6 +147,7 @@ redis:
   enabled: true
   host: '{{ $.Release.Name }}-redis'
   port: 6379
+  db: 0
 
   auth: true
   existingSecret: null


### PR DESCRIPTION
This pull request adds the functionality to select a specific Redis database number, which is a common requirement when using a shared Redis instance for multiple applications.

#### Description

By default, Redis connections use database `0`. This change introduces a new `redis.db` value in `values.yaml`, allowing users to override this default.

The key changes are:

1.  **`charts/dawarich/values.yaml`**:
    *   A new `db` key has been added to the `redis` section, with a default value of `0`.

2.  **`charts/dawarich/templates/_helpers.tpl`**:
    *   The `REDIS_URL` connection string is now constructed to include the database number (e.g., `redis://...:6379/0`).
    *   It uses `{{ .db | default 0 }}` to safely handle cases where the `db` value is not specified in `values.yaml`, ensuring full backward compatibility with existing configurations.
